### PR TITLE
Replace potentially copyrighted music with royalty-free music

### DIFF
--- a/projects/ngx-audio-player/src/lib/component/mat-basic-audio-player/mat-basic-audio-player.component.spec.ts
+++ b/projects/ngx-audio-player/src/lib/component/mat-basic-audio-player/mat-basic-audio-player.component.spec.ts
@@ -47,7 +47,7 @@ describe('MatBasicAudioPlayerComponent', () => {
     });
 
     it('should have play button', () => {
-      component.audioUrl = "https://www.dropbox.com/s/2t968nilfzbxflv/Mechanical%20Sundariye.mp3?dl=1";
+      component.audioUrl = "https://files.freemusicarchive.org/storage-freemusicarchive-org/music/WFMU/Broke_For_Free/Directionless_EP/Broke_For_Free_-_01_-_Night_Owl.mp3";
       fixture.detectChanges();
       element(By.css("button .play-track")).click();
       expect(By.css(".pause-track")).not.toBeNull;
@@ -81,7 +81,7 @@ describe('MatBasicAudioPlayerComponent', () => {
 
   /** Test Basic Player */
   @Component({
-    template: `<mat-basic-audio-player class="col-12 col-md-6" [audioUrl]="'https://www.dropbox.com/s/2t968nilfzbxflv/Mechanical%20Sundariye.mp3?dl=1'" [title]="'Mechanical Sundariye'"
+    template: `<mat-basic-audio-player class="col-12 col-md-6" [audioUrl]="'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/WFMU/Broke_For_Free/Directionless_EP/Broke_For_Free_-_01_-_Night_Owl.mp3'" [title]="'Night Owl (by Broke For Free)'"
     [displayTitle]="" [displayVolumeControls]="true"></mat-basic-audio-player>`
   })
 

--- a/projects/ngx-audio-player/src/lib/model/track.model.mock.ts
+++ b/projects/ngx-audio-player/src/lib/model/track.model.mock.ts
@@ -1,20 +1,24 @@
 import { Track } from './track.model';
 
 export const mockTrack1: Track = new Track();
-mockTrack1.link = 'https://www.dropbox.com/s/q1qaf8vn2dv48nw/Punjab.mp3?dl=1';
-mockTrack1.title = 'Punjab';
+mockTrack1.link = 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/WFMU/Broke_For_Free/Directionless_EP/Broke_For_Free_-_01_-_Night_Owl.mp3';
+mockTrack1.title = 'Night Owl (by Broke For Free)';
 
 export const mockPlaylist: Track[] = [
     {
-        title: 'Mechanical Sundariye',
-        link: 'https://www.dropbox.com/s/2t968nilfzbxflv/Mechanical%20Sundariye.mp3?dl=1'
+        title: '1400 (by Yung Kartz)',
+        link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/no_curator/Yung_Kartz/August_2018/Yung_Kartz_-_10_-_1400.mp3'
     },
     {
-        title: 'Vishnu',
-        link: 'https://www.dropbox.com/s/uxtnltcjk31k7nz/Vishnu.mp3?dl=1'
+        title: 'Epic Song (by BoxCat Games)',
+        link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/ccCommunity/BoxCat_Games/Nameless_The_Hackers_RPG_Soundtrack/BoxCat_Games_-_10_-_Epic_Song.mp3'
     },
     {
-        title: 'Punjab',
-        link: 'https://www.dropbox.com/s/q1qaf8vn2dv48nw/Punjab.mp3?dl=1'
-    }
+        title: 'Hachiko (The Faithful Dog) (by The Kyoto)',
+        link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/ccCommunity/The_Kyoto_Connection/Wake_Up/The_Kyoto_Connection_-_09_-_Hachiko_The_Faithtful_Dog.mp3'
+    },
+    {
+        title: 'Starling (by Podington Bear)',
+        link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/Music_for_Video/Podington_Bear/Solo_Instruments/Podington_Bear_-_Starling.mp3'
+    },
 ];

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -9,8 +9,8 @@ import { Track } from 'ngx-audio-player';
 export class HomeComponent {
   
   // Material Style Basic Audio Player Title and Audio URL
-  msbapTitle = 'Punjab';
-  msbapAudioUrl = 'https://www.dropbox.com/s/q1qaf8vn2dv48nw/Punjab.mp3?dl=1';
+  msbapTitle = 'Night Owl (by Broke For Free)';
+  msbapAudioUrl = 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/WFMU/Broke_For_Free/Directionless_EP/Broke_For_Free_-_01_-_Night_Owl.mp3';
 
   msbapDisplayTitle = false;
   msbapDisplayVolumeControls = true;
@@ -18,20 +18,20 @@ export class HomeComponent {
   // Material Style Advance Audio Player Playlist
   msaapPlaylist: Track[] = [
     {
-      title: 'Mechanical Sundariye',
-      link: 'https://www.dropbox.com/s/2t968nilfzbxflv/Mechanical%20Sundariye.mp3?dl=1'
+      title: '1400 (by Yung Kartz)',
+      link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/no_curator/Yung_Kartz/August_2018/Yung_Kartz_-_10_-_1400.mp3'
     },
     {
-      title: 'Vishnu',
-      link: 'https://www.dropbox.com/s/uxtnltcjk31k7nz/Vishnu.mp3?dl=1'
+      title: 'Epic Song (by BoxCat Games)',
+      link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/ccCommunity/BoxCat_Games/Nameless_The_Hackers_RPG_Soundtrack/BoxCat_Games_-_10_-_Epic_Song.mp3'
     },
     {
-      title: 'Naalo Chilipi Kala',
-      link: 'http://mp3sensongs.com/mp32/mp3/2018/Lover%20(2018)/Naalo%20Chilipi%20Kala%20(Theme%20Song)%20-%20SenSongsMp3.Co.mp3'
+      title: 'Hachiko (The Faithful Dog) (by The Kyoto)',
+      link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/ccCommunity/The_Kyoto_Connection/Wake_Up/The_Kyoto_Connection_-_09_-_Hachiko_The_Faithtful_Dog.mp3'
     },
     {
-      title: 'Punjab',
-      link: 'https://www.dropbox.com/s/q1qaf8vn2dv48nw/Punjab.mp3?dl=1'
+      title: 'Starling (by Podington Bear)',
+      link: 'https://files.freemusicarchive.org/storage-freemusicarchive-org/music/Music_for_Video/Podington_Bear/Solo_Instruments/Podington_Bear_-_Starling.mp3'
     },
   ];
 


### PR DESCRIPTION
Royalty-free music provided by https://freemusicarchive.com.

This prevents potential copyright issues in the future or a possible DMCA takedown of the repository/former MP3 files hosted on Dropbox.

Closes #24.