### PR TITLE
Fixed #7 - Audio won't load/play on iOS

### DIFF
--- a/projects/ngx-audio-player/src/lib/component/base/base-audio-player-components.ts
+++ b/projects/ngx-audio-player/src/lib/component/base/base-audio-player-components.ts
@@ -10,7 +10,9 @@ export class BaseAudioPlayerFunctions {
     @ViewChild('audioPlayer', {static: true}) player: ElementRef;
     timeLineDuration: MatSlider;
 
-    iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    iOS = (/iPad|iPhone|iPod/.test(navigator.platform) 
+        || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) 
+        && !window.MSStream;
 
     loaderDisplay = false;
     isPlaying = false;


### PR DESCRIPTION
- my testing showed that the check for IOS device was returning false on iPad, but true on iPhone.  This resulted in the play button not displaying on iPad.
- updating the check for IOS according to kikiwora's answer on https://stackoverflow.com/questions/9038625/detect-if-device-is-ios fixed the issue.
- thanks for all you do and such a useful library!

** I've not contributed to may projects via github.  Please let me know if I am making any procedural mistakes :). I'd like to contribute other code to this project, so I'd like to be sure I am sharing my updates properly.  Thanks again!