### PR TITLE
BrowserAnimationsModule should be imported only once by the using app's root app.module

### DIFF
--- a/projects/ngx-audio-player/src/lib/ngx-audio-player.module.ts
+++ b/projects/ngx-audio-player/src/lib/ngx-audio-player.module.ts
@@ -14,12 +14,11 @@ import { SecondsToMinutesPipe } from './pipe/seconds-to-minutes';
 import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { AudioPlayerComponent } from './component/ngx-audio-player/ngx-audio-player.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [SecondsToMinutesPipe, AudioPlayerComponent],
   imports: [CommonModule, FormsModule, MatButtonModule, MatCardModule, MatTableModule, MatFormFieldModule,
-    MatSliderModule, MatExpansionModule, MatPaginatorModule, MatIconModule, BrowserAnimationsModule],
+    MatSliderModule, MatExpansionModule, MatPaginatorModule, MatIconModule],
   exports: [AudioPlayerComponent]
 })
 export class NgxAudioPlayerModule {


### PR DESCRIPTION
This fixes the error, "BrowserModule has already been loaded" by an application that uses this package
(in my case, Angular 10.2.3)